### PR TITLE
add authorize extension for fields and types

### DIFF
--- a/examples/StarWars/Types/QueryType.cs
+++ b/examples/StarWars/Types/QueryType.cs
@@ -9,6 +9,8 @@ namespace StarWars.Types
     {
         protected override void Configure(IObjectTypeDescriptor<Query> descriptor)
         {
+            
+
             descriptor.Field(t => t.GetHero(default))
                 .Type<CharacterType>()
                 .Argument("episode", a => a.DefaultValue(Episode.NewHope));
@@ -20,7 +22,7 @@ namespace StarWars.Types
             // identity has a country
             descriptor.Field(t => t.Search(default))
                 .Type<ListType<SearchResultType>>()
-                .Directive(new AuthorizeDirective("HasCountry"));
+                .Authorize("HasCountry");
         }
     }
 

--- a/src/AspNetCore.Authorization/DescriptorExtensions.cs
+++ b/src/AspNetCore.Authorization/DescriptorExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using HotChocolate.Types;
+
+namespace HotChocolate.AspNetCore
+{
+    public static class ObjectTypeDescriptorExtensions
+    {
+        public static IObjectTypeDescriptor Authorize(this IObjectTypeDescriptor self, string policy)
+        {
+            return self.Directive(new AuthorizeDirective(policy));
+        }
+        
+        public static IObjectFieldDescriptor Authorize(this IObjectFieldDescriptor self, string policy)
+        {
+            return self.Directive(new AuthorizeDirective(policy));
+        }
+
+    }
+}


### PR DESCRIPTION
so can now add a policy to a field or type by writing
```
descriptor.Authorize("HasCountry");
```
or
```
descriptor.Field(t => t.Search(default)).Authorize("HasCountry");
```